### PR TITLE
Simplifying layout and DOM

### DIFF
--- a/src/services/preact-canvas/components/cell/index.tsx
+++ b/src/services/preact-canvas/components/cell/index.tsx
@@ -14,7 +14,7 @@
 import { Component, h } from "preact";
 import { Cell, Tag } from "../../../../gamelogic/types.js";
 import { bind } from "../../../../utils/bind.js";
-import { cellInner, tableCell } from "./style.css";
+import { button, gameCell } from "./style.css";
 
 interface State {}
 
@@ -40,19 +40,23 @@ export const enum Action {
 const Item = ({ cell, onUnrevealedClick, onTouchingClick }: ItemProps) => {
   if (!cell.revealed) {
     return (
-      <button onClick={onUnrevealedClick} class="cell unrevealed">
-        {cell.tag === Tag.Flag ? "🚩" : " "}
+      <button class={button} onClick={onUnrevealedClick}>
+        {cell.tag === Tag.Flag ? "Flagged" : "Unrevealed"}
       </button>
     );
   }
   if (cell.hasMine) {
-    return <button class="cell mine">💣</button>;
+    return <div>Mine</div>;
   }
   if (cell.touching > 0) {
-    return <button onClick={onTouchingClick}>{cell.touching}</button>;
+    return (
+      <button class={button} onClick={onTouchingClick}>
+        {cell.touching}
+      </button>
+    );
   }
 
-  return <button class="cell empty" />;
+  return null;
 };
 
 export default class GridCell extends Component<Props, State> {
@@ -95,14 +99,12 @@ export default class GridCell extends Component<Props, State> {
       : cell.touching;
 
     return (
-      <td class={tableCell}>
-        <div class={cellInner} data-state={cellState}>
-          <Item
-            cell={cell}
-            onUnrevealedClick={this.onUnrevealedClick}
-            onTouchingClick={this.onTouchingClick}
-          />
-        </div>
+      <td class={gameCell} data-state={cellState}>
+        <Item
+          cell={cell}
+          onUnrevealedClick={this.onUnrevealedClick}
+          onTouchingClick={this.onTouchingClick}
+        />
       </td>
     );
   }

--- a/src/services/preact-canvas/components/cell/style.css
+++ b/src/services/preact-canvas/components/cell/style.css
@@ -1,9 +1,17 @@
-.table-cell {
-  padding: 0;
-}
-
-.cell-inner {
+.game-cell {
+  display: block;
   width: 20px;
   height: 20px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.button {
+  width: 20px;
+  height: 20px;
+  appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  padding: 0;
   overflow: hidden;
 }

--- a/src/services/preact-canvas/components/game/index.tsx
+++ b/src/services/preact-canvas/components/game/index.tsx
@@ -16,7 +16,7 @@ import { Cell } from "../../../../gamelogic/types";
 import { bind } from "../../../../utils/bind.js";
 import StateService from "../../../state.js";
 import { Action } from "../cell/index.js";
-import { cellInner } from "../cell/style.css";
+import { gameCell } from "../cell/style.css";
 import Row from "../row/index.js";
 import { canvas, container, gameTable } from "./style.css";
 
@@ -46,7 +46,7 @@ export default class Game extends Component<Props> {
     new MutationObserver(entries => {
       for (const entry of entries) {
         const element = entry.target as HTMLElement;
-        if (element.classList.contains(cellInner)) {
+        if (element.classList.contains(gameCell)) {
           this.cellsToRedraw.add(element);
         }
       }
@@ -121,7 +121,7 @@ export default class Game extends Component<Props> {
     this.ctx = this.canvas!.getContext("2d")!;
     this.ctx.scale(devicePixelRatio, devicePixelRatio);
 
-    for (const cell of this.table!.querySelectorAll("." + cellInner)) {
+    for (const cell of this.table!.querySelectorAll("." + gameCell)) {
       this.cellsToRedraw.add(cell);
     }
 

--- a/src/services/preact-canvas/components/game/style.css
+++ b/src/services/preact-canvas/components/game/style.css
@@ -1,8 +1,7 @@
 .game-table {
   background: #fff;
-  table-layout: fixed;
-  border-spacing: 0;
   position: relative;
+  display: block;
   opacity: 0;
 }
 

--- a/src/services/preact-canvas/components/row/index.tsx
+++ b/src/services/preact-canvas/components/row/index.tsx
@@ -14,6 +14,7 @@
 import { Component, h } from "preact";
 import { Cell } from "../../../../gamelogic/types.js";
 import GridCell, { Action } from "../cell/index.js";
+import { gameRow } from "./style.css";
 
 interface State {}
 
@@ -29,7 +30,7 @@ export default class Row extends Component<Props, State> {
 
   render({ row, onClick }: Props) {
     return (
-      <tr>
+      <tr class={gameRow}>
         {row.map((cell, i) => (
           <GridCell onClick={onClick.bind(this, i)} cell={cell} />
         ))}

--- a/src/services/preact-canvas/components/row/style.css
+++ b/src/services/preact-canvas/components/row/style.css
@@ -1,0 +1,3 @@
+.game-row {
+  display: flex;
+}

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -11,13 +11,11 @@
  * limitations under the License.
  */
 
-import { proxy, Remote } from "comlink/src/comlink.js";
+import { Remote } from "comlink/src/comlink.js";
 import { Component, h, render } from "preact";
-
-import StateService, { StateUpdate } from "../state.js";
-
 import { Cell, State as GameState } from "../../gamelogic/types";
 import localStateSubscribe from "../local-state-subscribe";
+import StateService from "../state.js";
 import Game from "./components/game/index.js";
 
 interface Props {


### PR DESCRIPTION
Removing table layout to reduce layout time. There may be more opportunities here too.

Removing the cell inner div seems to have improved diff time too. Although, it's still 100ms on a macbook.