### PR TITLE
Change preset names & start centered

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -61,13 +61,19 @@ export default class Board extends Component<Props> {
   >();
 
   componentDidMount() {
-    window.scrollTo(0, 0);
     document.documentElement.classList.add("in-game");
     this._createTable(this.props.width, this.props.height);
     this.props.gameChangeSubscribe(this._doManualDomHandling);
     this._rendererInit();
     this._queryFirstCellRect();
     this.props.renderer.updateFirstRect(this._firstCellRect!);
+
+    // Center scroll position
+    const root = document.documentElement;
+    window.scrollTo(
+      root.scrollWidth / 2 - root.offsetWidth / 2,
+      root.scrollHeight / 2 - root.offsetHeight / 2
+    );
 
     window.addEventListener("resize", this._onWindowResize);
     window.addEventListener("scroll", this._onWindowScroll);

--- a/src/services/preact-canvas/components/intro/index.tsx
+++ b/src/services/preact-canvas/components/intro/index.tsx
@@ -140,7 +140,7 @@ export default class Intro extends Component<Props, State> {
         <form onSubmit={this._startGame} class={startFormStyle}>
           <div class={settingsRowStyle}>
             <label class={labelStyle}>
-              <span class={labelTextStyle}>Preset</span>
+              <span class={labelTextStyle}>Difficulty</span>
               <Arrow class={selectArrowStyle} />
               <select
                 required
@@ -150,9 +150,9 @@ export default class Intro extends Component<Props, State> {
                 value={presetName || ""}
               >
                 {presetName && [
-                  <option value="beginner">Beginner</option>,
-                  <option value="advanced">Advanced</option>,
-                  <option value="expert">Expert</option>,
+                  <option value="easy">Easy</option>,
+                  <option value="normal">Normal</option>,
+                  <option value="hard">Hard</option>,
                   <option value="custom">Custom</option>
                 ]}
               </select>

--- a/src/services/state/grid-default.ts
+++ b/src/services/state/grid-default.ts
@@ -15,16 +15,16 @@ export async function getGridDefault(): Promise<GridType> {
   const gridDefault = await get(key);
 
   if (!gridDefault) {
-    return presets.beginner;
+    return presets.normal;
   }
 
   return gridDefault as GridType;
 }
 
 export const presets = {
-  advanced: { width: 16, height: 16, mines: 40 },
-  beginner: { width: 8, height: 8, mines: 10 },
-  expert: { width: 24, height: 24, mines: 99 }
+  easy: { width: 8, height: 8, mines: 10 },
+  normal: { width: 16, height: 16, mines: 40 },
+  hard: { width: 24, height: 24, mines: 99 }
 };
 
 export type PresetName = keyof typeof presets;


### PR DESCRIPTION
Fixes #156.

I changed the name of the presets to "easy", "normal", "hard" and made "normal" the default.

This is for aesthetic reasons, as it means the grid fills the screen on mobile. I'm not sure how I feel that, but it does make the first play look better.