### PR TITLE
Reimplement scrolling from wheel

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -73,7 +73,7 @@ export default class Board extends Component<Props> {
     window.addEventListener("scroll", this._onWindowScroll);
     window.addEventListener("keydown", this._onKeyDown);
     window.addEventListener("keyup", this._onKeyUp);
-    window.addEventListener("wheel", this._onWindowWheel);
+    window.addEventListener("wheel", this._onWindowWheel, { passive: false });
   }
 
   componentWillUnmount() {

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -73,6 +73,7 @@ export default class Board extends Component<Props> {
     window.addEventListener("scroll", this._onWindowScroll);
     window.addEventListener("keydown", this._onKeyDown);
     window.addEventListener("keyup", this._onKeyUp);
+    window.addEventListener("wheel", this._onWindowWheel);
   }
 
   componentWillUnmount() {
@@ -81,6 +82,7 @@ export default class Board extends Component<Props> {
     window.removeEventListener("scroll", this._onWindowScroll);
     window.removeEventListener("keydown", this._onKeyDown);
     window.removeEventListener("keyup", this._onKeyUp);
+    window.removeEventListener("wheel", this._onWindowWheel);
     this.props.gameChangeUnsubscribe(this._doManualDomHandling);
     this.props.renderer.stop();
     this.props.animator.stop();
@@ -102,6 +104,15 @@ export default class Board extends Component<Props> {
   private _onWindowResize() {
     this._onWindowScroll();
     this.props.renderer.onResize();
+  }
+
+  @bind
+  private _onWindowWheel(event: WheelEvent) {
+    if (event.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
+      return;
+    }
+    event.preventDefault();
+    window.scrollBy(event.deltaX, event.deltaY);
   }
 
   @bind


### PR DESCRIPTION
Just a hack right now.

By default, Chrome & Safari seem to 'lock' scrolling to horizontal or vertical. That seems weird for our game. So, here I reimplement scrolling from the wheel events. The allows diagonal scrolling on a mac trackpad.

Some thoughts / observations:

* This makes scrolling in Firefox pretty broken, although diagonal scrolling already worked there, so a hack like this could use UA-sniffing.
* I've only tested with a mouse & trackpad on mac. It's possible this breaks things on other device combinations.

@surma @kosamari do you think this is worth pursuing?