### PR TITLE
Prevent mines appearing in a 3x3 grid around the initial tap

### DIFF
--- a/src/gamelogic/index.ts
+++ b/src/gamelogic/index.ts
@@ -70,7 +70,10 @@ export default class MinesweeperGame {
     if (_width < 1 || _height < 1) {
       throw Error("Invalid dimensions");
     }
-    if (_mines >= _width * _height) {
+
+    const maxMines = _width * _height - 9;
+
+    if (_mines > maxMines) {
       throw Error("Number of mines cannot fit in grid");
     }
 
@@ -241,8 +244,18 @@ export default class MinesweeperGame {
       .fill(undefined)
       .map((_, i) => i);
 
-    // Remove the cell played.
-    flatCellIndexes.splice(avoidY * this._width + avoidX, 1);
+    // Remove a 3x3 grid around the cell played.
+    const indexesToRemove = [avoidY * this._width + avoidX];
+
+    for (const [nextX, nextY] of this._getSurrounding(avoidX, avoidY)) {
+      indexesToRemove.push(nextY * this._width + nextX);
+    }
+
+    indexesToRemove.sort((a, b) => a - b);
+
+    for (const [removed, indexToRemove] of indexesToRemove.entries()) {
+      flatCellIndexes.splice(indexToRemove - removed, 1);
+    }
 
     // Place mines in remaining squares
     let minesToPlace = this._mines;

--- a/src/services/preact-canvas/components/intro/index.tsx
+++ b/src/services/preact-canvas/components/intro/index.tsx
@@ -227,10 +227,11 @@ export default class Intro extends Component<Props, State> {
     const width = this._widthInput!.valueAsNumber;
     const height = this._heightInput!.valueAsNumber;
     const mines = this._minesInput!.valueAsNumber;
+    const maxMines = width * height - 9;
 
     this.setState({
       height,
-      mines: mines >= width * height ? width * height - 1 : mines,
+      mines: mines > maxMines ? maxMines : mines,
       presetName: getPresetName(width, height, mines),
       width
     });


### PR DESCRIPTION
Fixes #237.

IMO this massively improves the experience. You don't need to churn at the start with 1 square reveals until you get a decent start.