### PR TITLE
Safari fixes for fullscreen

### DIFF
--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -25,3 +25,7 @@ declare var ga: GA;
 interface Window {
   ga: GA;
 }
+
+interface HTMLElement {
+  webkitRequestFullscreen?: () => void;
+}

--- a/src/services/preact-canvas/components/bottom-bar/index.tsx
+++ b/src/services/preact-canvas/components/bottom-bar/index.tsx
@@ -26,8 +26,20 @@ import {
   toggleContainer
 } from "./style.css";
 
+function goFullscreen() {
+  if (document.documentElement.requestFullscreen) {
+    document.documentElement.requestFullscreen();
+  } else if (document.documentElement.webkitRequestFullscreen) {
+    document.documentElement.webkitRequestFullscreen();
+  }
+}
+
+const fullscreenSupported: boolean = !!(
+  document.documentElement.requestFullscreen ||
+  document.documentElement.webkitRequestFullscreen
+);
+
 export interface Props {
-  onFullscreenClick: () => void;
   onSettingsClick: () => void;
   onBackClick: () => void;
   onDangerModeChange: (newSetting: boolean) => void;
@@ -50,7 +62,6 @@ export default class BottomBar extends Component<Props, State> {
 
   render(
     {
-      onFullscreenClick,
       onSettingsClick,
       onBackClick,
       buttonType,
@@ -126,13 +137,15 @@ export default class BottomBar extends Component<Props, State> {
             />
           </div>
         )}
-        <button
-          class={fullscreen}
-          onClick={onFullscreenClick}
-          aria-label="fullscreen mode"
-        >
-          <Fullscreen />
-        </button>
+        {fullscreenSupported && (
+          <button
+            class={fullscreen}
+            onClick={goFullscreen}
+            aria-label="fullscreen mode"
+          >
+            <Fullscreen />
+          </button>
+        )}
       </div>
     );
   }

--- a/src/services/preact-canvas/components/bottom-bar/style.css
+++ b/src/services/preact-canvas/components/bottom-bar/style.css
@@ -53,6 +53,12 @@ html:fullscreen .fullscreen {
   visibility: hidden;
 }
 
+/* For Safari. This can't be combined with the rule above, as Safari sees :fullscreen as invalid,
+and craps itself. */
+html:-webkit-full-screen .fullscreen {
+  visibility: hidden;
+}
+
 @media (display-mode: fullscreen) {
   .fullscreen {
     visibility: hidden;

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -95,9 +95,7 @@ const texturePromise = import("../../rendering/animation").then(m =>
 );
 
 const gamePerquisites = texturePromise;
-
 const gridDefaultPromise = getGridDefault();
-
 const immedateGameSessionKey = "instantGame";
 
 class PreactService extends Component<Props, State> {
@@ -186,7 +184,6 @@ class PreactService extends Component<Props, State> {
         />
         {mainComponent}
         <BottomBar
-          onFullscreenClick={this._onFullscreenClick}
           onSettingsClick={this._onSettingsClick}
           onBackClick={this._onBackClick}
           onDangerModeChange={this._onDangerModeChange}
@@ -239,11 +236,6 @@ class PreactService extends Component<Props, State> {
   @bind
   private _onGameChangeUnsubscribe(func: GameChangeCallback) {
     this._gameChangeSubscribers.delete(func);
-  }
-
-  @bind
-  private _onFullscreenClick() {
-    document.documentElement.requestFullscreen();
   }
 
   @bind


### PR DESCRIPTION
Baby step. Fullscreen button now works in Safari, and isn't shown on iPhone.