### PR TITLE
Disable buttons if it's not clickable

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -389,13 +389,15 @@ export default class Board extends Component<Props, State> {
     } else {
       cellLabel = `${cell.touchingMines}`;
     }
-    const isDisabled =
-      cell.revealed &&
-      (cell.touchingMines <= 0 || cell.touchingFlags <= 0 || cell.hasMine);
+    const clickable =
+      !cell.revealed ||
+      (cell.touchingMines && cell.touchingFlags >= cell.touchingMines);
 
-    isDisabled
-      ? btn.setAttribute("disabled", "")
-      : btn.removeAttribute("disabled");
+    if (clickable) {
+      btn.removeAttribute("disabled");
+    } else {
+      btn.disabled = !clickable;
+    }
 
     btn.setAttribute("aria-label", cellLabel);
     this._additionalButtonData.get(btn)![2] = cell;

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -378,23 +378,26 @@ export default class Board extends Component<Props, State> {
     x: number,
     y: number
   ) {
-    // Create text for aria-label, then check if the buttun should be active or disabled
-    let cellState: [string, boolean];
-    if (!cell.revealed) {
-      const label = cell.flagged ? "flag" : "hidden";
-      cellState = [label, true];
-    } else if (cell.hasMine) {
-      cellState = ["black hole", false];
-    } else if (cell.touchingMines === 0) {
-      cellState = ["blank", false];
-    } else {
-      cellState = [`${cell.touchingMines}`, cell.touchingFlags > 0];
-    }
+    let cellLabel: string;
 
-    cellState[1]
-      ? btn.removeAttribute("disabled")
-      : btn.setAttribute("disabled", "true");
-    btn.setAttribute("aria-label", cellState[0]);
+    if (!cell.revealed) {
+      cellLabel = cell.flagged ? "flag" : "hidden";
+    } else if (cell.hasMine) {
+      cellLabel = "black hole";
+    } else if (cell.touchingMines === 0) {
+      cellLabel = "blank";
+    } else {
+      cellLabel = `${cell.touchingMines}`;
+    }
+    const isDisabled =
+      cell.revealed &&
+      (cell.touchingMines <= 0 || cell.touchingFlags <= 0 || cell.hasMine);
+
+    isDisabled
+      ? btn.setAttribute("disabled", "true")
+      : btn.removeAttribute("disabled");
+
+    btn.setAttribute("aria-label", cellLabel);
     this._additionalButtonData.get(btn)![2] = cell;
   }
 }

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -379,6 +379,7 @@ export default class Board extends Component<Props, State> {
     y: number
   ) {
     let cellState;
+
     if (!cell.revealed) {
       cellState = cell.flagged ? `flag` : `hidden`;
     } else if (cell.hasMine) {
@@ -386,9 +387,15 @@ export default class Board extends Component<Props, State> {
     } else if (cell.touchingMines === 0) {
       cellState = `blank`;
     } else {
-      cellState = `${cell.touchingMines}`;
+      cellState = `${cell.touchingMines}, ${cell.touchingFlags}`;
     }
+    // todo see if it's active number or not
 
+    if (cellState === "blank" || cellState === "black hole") {
+      btn.setAttribute("disabled", "true");
+    } else {
+      btn.removeAttribute("disabled");
+    }
     btn.setAttribute("aria-label", cellState);
     this._additionalButtonData.get(btn)![2] = cell;
   }

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -394,7 +394,7 @@ export default class Board extends Component<Props, State> {
       (cell.touchingMines <= 0 || cell.touchingFlags <= 0 || cell.hasMine);
 
     isDisabled
-      ? btn.setAttribute("disabled", "true")
+      ? btn.setAttribute("disabled", "")
       : btn.removeAttribute("disabled");
 
     btn.setAttribute("aria-label", cellLabel);

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -392,13 +392,7 @@ export default class Board extends Component<Props, State> {
     const clickable =
       !cell.revealed ||
       (cell.touchingMines && cell.touchingFlags >= cell.touchingMines);
-
-    if (clickable) {
-      btn.removeAttribute("disabled");
-    } else {
-      btn.disabled = !clickable;
-    }
-
+    btn.disabled = !clickable;
     btn.setAttribute("aria-label", cellLabel);
     this._additionalButtonData.get(btn)![2] = cell;
   }

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -378,25 +378,23 @@ export default class Board extends Component<Props, State> {
     x: number,
     y: number
   ) {
-    let cellState;
-
+    // Create text for aria-label, then check if the buttun should be active or disabled
+    let cellState: [string, boolean];
     if (!cell.revealed) {
-      cellState = cell.flagged ? `flag` : `hidden`;
+      const label = cell.flagged ? "flag" : "hidden";
+      cellState = [label, true];
     } else if (cell.hasMine) {
-      cellState = `black hole`;
+      cellState = ["black hole", false];
     } else if (cell.touchingMines === 0) {
-      cellState = `blank`;
+      cellState = ["blank", false];
     } else {
-      cellState = `${cell.touchingMines}, ${cell.touchingFlags}`;
+      cellState = [`${cell.touchingMines}`, cell.touchingFlags > 0];
     }
-    // todo see if it's active number or not
 
-    if (cellState === "blank" || cellState === "black hole") {
-      btn.setAttribute("disabled", "true");
-    } else {
-      btn.removeAttribute("disabled");
-    }
-    btn.setAttribute("aria-label", cellState);
+    cellState[1]
+      ? btn.removeAttribute("disabled")
+      : btn.setAttribute("disabled", "true");
+    btn.setAttribute("aria-label", cellState[0]);
     this._additionalButtonData.get(btn)![2] = cell;
   }
 }


### PR DESCRIPTION
Currently implementation of the game, screen reader will announce every cell as clickable item regardless of the cell state.

This PR put `disabled` attribute in buttons which are not clickable (revealed, black hole, and white number).  This will make sighted user and blind user's experience the same. 

closes #274 