### PR TITLE
[WIP] Move focused element into the view

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -135,6 +135,7 @@ export default class Board extends Component<Props, State> {
         event.key === "0")
     ) {
       this.moveFocusByKey(event, 0, 0);
+      document.activeElement!.scrollIntoView();
     }
   }
 
@@ -297,6 +298,7 @@ export default class Board extends Component<Props, State> {
   private onKeyUpOnTable(event: KeyboardEvent) {
     if (event.key === "Tab") {
       this.moveFocusByKey(event, 0, 0);
+      document.activeElement!.scrollIntoView();
     }
   }
 


### PR DESCRIPTION
Closes: #327 
Still work in progress - we need to solve cells being hidden behind top-bar. 

How to see it :
- start Normal or Hard mode 
- Hit `Tab` see the grid move, but not see the focus dot on any element. 
- scroll up slightly, ah-ha! there is focus on top-left corner. 
