### PR TITLE
Fix ordering of clamp arguments

### DIFF
--- a/src/services/preact-canvas/components/nebula/fragment.glsl
+++ b/src/services/preact-canvas/components/nebula/fragment.glsl
@@ -132,7 +132,7 @@ void main() {
     float d = length(p) - radius;
     float circle_mask = (1. - smoothstep(0., 0.01, d));
 
-    circle_color = clamp(vec4(0.), vec4(1.), circle_color + mix(black, alt_color_light*.1, circle_mask));
+    circle_color = clamp(circle_color + mix(black, alt_color_light*.1, circle_mask), vec4(0.), vec4(1.));
   }
 
 
@@ -149,7 +149,7 @@ void main() {
     float d = length(p) - radius;
     float circle_mask = (1. - smoothstep(0., 0.01, d));
 
-    circle_color = clamp(vec4(0.), vec4(1.), circle_color + mix(black, alt_color_light*.1, circle_mask));
+    circle_color = clamp(circle_color + mix(black, alt_color_light*.1, circle_mask), vec4(0.), vec4(1.));
   }
 
   // Circle 3
@@ -165,7 +165,7 @@ void main() {
     float d = length(p) - radius;
     float circle_mask = (1. - smoothstep(0., 0.01, d));
 
-    circle_color = clamp(vec4(0.), vec4(1.), circle_color + mix(black, alt_color_light*.1, circle_mask));
+    circle_color = clamp(circle_color + mix(black, alt_color_light*.1, circle_mask), vec4(0.), vec4(1.));
   }
 
   // Soft light blending


### PR DESCRIPTION
Even though mix is defined as (x, y, a) [1], clamp is defined as (a, x,
y) [2] where x is the lowerbound and y is the upperbound. This breaks on
Linux, which enforces the WebGL argument ordering and is likely working
on the other platforms where it patches the argument ordering on the
fly.

[1]: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/mix.xhtml
[2]: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/clamp.xhtml