### PR TITLE
Increase toggle hit region

### DIFF
--- a/src/services/preact-canvas/components/bottom-bar/index.tsx
+++ b/src/services/preact-canvas/components/bottom-bar/index.tsx
@@ -23,7 +23,8 @@ import {
   noFullscreen,
   rightToggleLabel,
   toggle,
-  toggleContainer
+  toggleContainer,
+  toggleLabel
 } from "./style.css";
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
@@ -97,7 +98,7 @@ export default class BottomBar extends Component<Props, State> {
             class={toggleContainer}
             onTouchStart={this._onDangerModeTouchStart}
           >
-            <label>
+            <label class={toggleLabel}>
               <span aria-hidden="true" class={leftToggleLabel}>
                 Clear
               </span>

--- a/src/services/preact-canvas/components/bottom-bar/style.css
+++ b/src/services/preact-canvas/components/bottom-bar/style.css
@@ -13,7 +13,7 @@
 .bottom-bar {
   display: flex;
   justify-content: space-between;
-  padding: var(--bar-padding) var(--side-margin) var(--side-margin);
+  padding: 0 var(--side-margin);
   position: relative;
   left: 0;
   right: 0;
@@ -25,6 +25,10 @@
 /* The in-game class is set by the game component */
 :global .in-game :local .bottom-bar {
   position: absolute;
+}
+
+.bottom-bar > button {
+  margin: var(--bar-padding) 0;
 }
 
 .bottom-bar::before {
@@ -93,6 +97,12 @@ html:-webkit-full-screen .fullscreen {
   align-self: center;
 }
 
+.toggle-label {
+  display: flex;
+  align-items: center;
+  padding: var(--bar-padding) 0;
+}
+
 .toggle {
   display: block;
   width: 32px;
@@ -107,24 +117,14 @@ html:-webkit-full-screen .fullscreen {
 
 .checkbox {
   opacity: 0;
+  /* Take the checkbox out of flow */
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .left-toggle-label,
 .right-toggle-label {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
   margin: 0 0.6rem;
   user-select: none;
-}
-
-.left-toggle-label {
-  right: 100%;
-}
-
-.right-toggle-label {
-  left: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 }

--- a/src/services/preact-canvas/components/bottom-bar/style.css
+++ b/src/services/preact-canvas/components/bottom-bar/style.css
@@ -98,8 +98,7 @@ html:-webkit-full-screen .fullscreen {
 }
 
 .toggle-label {
-  display: flex;
-  align-items: center;
+  display: block;
   padding: var(--bar-padding) 0;
 }
 
@@ -117,8 +116,9 @@ html:-webkit-full-screen .fullscreen {
 
 .checkbox {
   opacity: 0;
-  /* Take the checkbox out of flow */
   position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .left-toggle-label,
@@ -127,4 +127,15 @@ html:-webkit-full-screen .fullscreen {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.left-toggle-label {
+  right: 100%;
+}
+
+.right-toggle-label {
+  left: 100%;
 }


### PR DESCRIPTION
I realized that I sometimes try to hit the toggle on mobile and I tap the region between the bottom bar border and the toggle and then nothing happens. It can be frustrating if you have sausage-y fingers like me.

I increased label to span the entire height of the bottom bar.

@jakearchibald PTAL if you agree with the way I achieved that.

I also switched the label to flexbox, because the absolute positioning seems unnecessary? 

I also fixed text highlighting on Safari and older FF.