### PR TITLE
Don't persist storage on Firefox.

### DIFF
--- a/src/services/state/best-times.ts
+++ b/src/services/state/best-times.ts
@@ -44,6 +44,11 @@ export function getBest(
 }
 
 // Trigger Persistent Storage while we are at it.
-if (navigator.storage && navigator.storage.persist) {
+// Firefox shows an ugly permission prompt that doesn't really make sense to users, so… nahhhh.
+if (
+  navigator.storage &&
+  navigator.storage.persist &&
+  !navigator.userAgent.includes("Firefox/")
+) {
   navigator.storage.persist();
 }


### PR DESCRIPTION
Because of permissions. Fixes #404.

