### PR TITLE
feature: flag block with Enter + modifier

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -352,7 +352,7 @@ export default class Board extends Component<Props, State> {
         return;
       }
       event.preventDefault();
-      this.simulateClick(button);
+      this.simulateClick(button, event.altKey);
     } else if (event.key === "ArrowRight" || event.key === "9") {
       this.moveFocusByKey(event, 1, 0);
     } else if (event.key === "ArrowLeft" || event.key === "7") {


### PR DESCRIPTION
Using keyboard only, I find it frustrating to switch between flag and clear modes (with F) and would prefer to hold down a modifier key while hitting Enter.

This PR implements it using ALT, but I'd be happy with any alternative if ALT has cross-platform issues.