### PR TITLE
Don't call navigator.vibrate if it isn't supported

### DIFF
--- a/src/services/preact-canvas/components/game/index.tsx
+++ b/src/services/preact-canvas/components/game/index.tsx
@@ -16,6 +16,7 @@ import { Animator } from "src/rendering/animator";
 import { Renderer } from "src/rendering/renderer";
 import StateService from "src/services/state";
 import { submitTime } from "src/services/state/best-times";
+import { supportsVibration } from "src/services/state/vibration-preference";
 import { bind } from "src/utils/bind";
 import { GameChangeCallback } from "../..";
 import { StateChange } from "../../../../gamelogic";
@@ -188,7 +189,7 @@ export default class Game extends Component<Props, State> {
       this._tryAgainBtn
     ) {
       this._tryAgainBtn.focus();
-      if (this.props.useVibration && "vibrate" in navigator) {
+      if (this.props.useVibration && supportsVibration) {
         navigator.vibrate(vibrationLength);
       }
     }

--- a/src/services/preact-canvas/components/game/index.tsx
+++ b/src/services/preact-canvas/components/game/index.tsx
@@ -188,7 +188,7 @@ export default class Game extends Component<Props, State> {
       this._tryAgainBtn
     ) {
       this._tryAgainBtn.focus();
-      if (this.props.useVibration) {
+      if (this.props.useVibration && "vibrate" in navigator) {
         navigator.vibrate(vibrationLength);
       }
     }

--- a/src/services/preact-canvas/components/settings/index.tsx
+++ b/src/services/preact-canvas/components/settings/index.tsx
@@ -13,6 +13,7 @@
 import { Component, h } from "preact";
 import { bind } from "src/utils/bind.js";
 import { isFeaturePhone } from "src/utils/static-display";
+import { supportsVibration } from "../../../state/vibration-preference";
 import About from "../about";
 import { Close } from "../icons/additional";
 import {
@@ -94,6 +95,7 @@ export default class Settings extends Component<Props, State> {
             <button
               class={useVibration ? btnOnStyle : btnOffStyle}
               onClick={onVibrationPrefChange}
+              disabled={!supportsVibration}
             >
               Vibrate {useVibration ? "on" : "off"}
             </button>

--- a/src/services/state/vibration-preference.ts
+++ b/src/services/state/vibration-preference.ts
@@ -1,6 +1,6 @@
 import { get, set } from "idb-keyval";
 
-const DEFAULT: boolean = true;
+export const supportsVibration = "vibrate" in navigator;
 
 /**
  * Set vibration preference (true means will vibrate)
@@ -17,5 +17,5 @@ export async function getVibrationPreference(): Promise<boolean> {
     return vibrate;
   }
   // if no value is assigned to "vibrate", return default value
-  return DEFAULT;
+  return supportsVibration;
 }


### PR DESCRIPTION
Fixes #462