### PR TITLE
Updated ecstatic to fix high severity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3171,9 +3171,9 @@
       },
       "dependencies": {
         "ecstatic": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.1.tgz",
-          "integrity": "sha512-/rrctvxZ78HMI/tPIsqdvFKHHscxR3IJuKrZI2ZoUgkt2SiufyLFBmcco+aqQBIu6P1qBsUNG3drAAGLx80vTQ==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+          "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
           "dev": true,
           "requires": {
             "he": "^1.1.1",


### PR DESCRIPTION
Details from npm:

| High | Open Redirect |
| ----- | ----- |
| Package | ecstatic |
| Dependency of | http-server [dev] |
| Path | http-server > ecstatic |
| More info | https://npmjs.com/advisories/830 |

Not super important as http-server is only used for dev, but security is important :-P.