### PR TITLE
Spatial navigation

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -86,12 +86,10 @@ export default class Board extends Component<Props, State> {
     // overflows the viewport on devices that hide the URL bar on scroll.
     window.scrollTo(0, 0);
 
-    // Center scroll position
-    const scroller = this.base!.querySelector(
-      "." + containerStyle
-    ) as HTMLElement;
-    scroller.scrollLeft = scroller.scrollWidth / 2 - scroller.offsetWidth / 2;
-    scroller.scrollTop = scroller.scrollHeight / 2 - scroller.offsetHeight / 2;
+    // Focus a cell near the center (also centers scroll position).
+    const x = Math.floor(this.props.width * 0.5);
+    const y = Math.floor(this.props.height * 0.5);
+    this.setFocus(this._buttons[y * this.props.width + x]);
 
     window.addEventListener("resize", this._onWindowResize);
     window.addEventListener("keyup", this._onKeyUp);


### PR DESCRIPTION
This change was kindly provided by @ianvollick.

To start Chrome with SpatNav enabled:
```
/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --enable-spatial-navigation --enable-features=FocuslessSpatialNavigation,KeyboardFocusableScrollers,Vid
eoAutoFullscreen --enable-blink-features=FocuslessSpatialNavigation,KeyboardFocusableScrollers,VideoAutoFullscreen http://localhost:8080
```

Arrow keys now navigate the “interest”. 

Worth testing the app a bit more with this navigational mode. The home screen is a bit odd, too.