### PR TITLE
Add Highlight toggle

### DIFF
--- a/src/rendering/canvas-2d-renderer/index.ts
+++ b/src/rendering/canvas-2d-renderer/index.ts
@@ -15,6 +15,7 @@ import { Cell } from "src/gamelogic/types";
 import { getCanvas } from "src/utils/canvas-pool";
 import { getBarHeights, getCellSizes } from "src/utils/cell-sizing";
 import { staticDevicePixelRatio } from "src/utils/static-display";
+import { getHighlights } from "../../services/state/highlights-preference";
 import {
   AnimationDesc,
   AnimationName,
@@ -61,6 +62,7 @@ export default class Canvas2DRenderer implements Renderer {
   private _numTilesY?: number;
   private _lastFocus = [-1, -1];
   private _gradients?: FadeOutGradient[];
+  private _highlights: boolean = false;
 
   get numTiles() {
     return this._numTilesX! * this._numTilesY!;
@@ -76,6 +78,10 @@ export default class Canvas2DRenderer implements Renderer {
   }
 
   init(numTilesX: number, numTilesY: number) {
+    getHighlights().then(hl => {
+      this._highlights = hl;
+    });
+
     this._numTilesX = numTilesX;
     this._numTilesY = numTilesY;
     this._updateTileSize();
@@ -333,6 +339,10 @@ export default class Canvas2DRenderer implements Renderer {
     animation: AnimationDesc,
     ts: number
   ) {
+    if (!cell.flagged && !this._highlights) {
+      this[AnimationName.HIGHLIGHT_OUT](x, y, cell, animation, ts);
+      return;
+    }
     const start = animation.fadeStart || animation.start;
     const animationLength = fadeInAnimationLength;
     let normalized = (ts - start) / animationLength;

--- a/src/rendering/motion-animator/index.ts
+++ b/src/rendering/motion-animator/index.ts
@@ -13,6 +13,7 @@
 
 import { Cell, GridChanges } from "src/gamelogic/types";
 import { bind } from "src/utils/bind";
+import { getHighlights } from "../../services/state/highlights-preference";
 import { AnimationDesc, AnimationName } from "../animation";
 import { removeAnimations } from "../animation-helpers";
 import { Animator } from "../animator";
@@ -33,12 +34,16 @@ export default class MotionAnimator implements Animator {
   private _cellDetails!: CellDetails[];
   private _changeBuffer: GridChanges = [];
   private _lastTs = getTime();
+  private _highlights: boolean = true;
 
   constructor(
     private _numTilesX: number,
     private _numTilesY: number,
     private _renderer: Renderer
   ) {
+    getHighlights().then(hl => {
+      this._highlights = hl;
+    });
     unfreeze();
     this._initCellDetails();
     this._startRenderLoop();
@@ -124,7 +129,8 @@ export default class MotionAnimator implements Animator {
       if (
         cell.touchingFlags >= cell.touchingMines &&
         cell.touchingMines > 0 &&
-        !isHighlighted
+        !isHighlighted &&
+        this._highlights
       ) {
         animationList.push({
           name: AnimationName.HIGHLIGHT_IN,

--- a/src/services/preact-canvas/components/settings/index.tsx
+++ b/src/services/preact-canvas/components/settings/index.tsx
@@ -38,6 +38,8 @@ interface Props {
   supportsSufficientWebGL: boolean;
   useVibration: boolean;
   onVibrationPrefChange: () => void;
+  onHighlightsChange: () => void;
+  highlights: boolean;
 }
 
 interface State {}
@@ -53,7 +55,9 @@ export default class Settings extends Component<Props, State> {
     supportsSufficientWebGL,
     disableAnimationBtn,
     useVibration,
-    onVibrationPrefChange
+    onVibrationPrefChange,
+    onHighlightsChange,
+    highlights
   }: Props) {
     const closeBtn = isFeaturePhone ? (
       <button
@@ -98,6 +102,12 @@ export default class Settings extends Component<Props, State> {
               disabled={!supportsVibration}
             >
               Vibrate {useVibration ? "on" : "off"}
+            </button>
+            <button
+              class={highlights ? btnOnStyle : btnOffStyle}
+              onClick={onHighlightsChange}
+            >
+              Hightlights {highlights ? "on" : "off"}
             </button>
             <About
               motion={motion}

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -99,6 +99,7 @@ interface State {
   gameInPlay: boolean;
   allowIntroAnim: boolean;
   vibrationPreference: boolean;
+  highlights: boolean;
 }
 
 export type GameChangeCallback = (stateChange: GameStateChange) => void;
@@ -125,7 +126,8 @@ export default class Root extends Component<Props, State> {
     motionPreference: true,
     gameInPlay: false,
     allowIntroAnim: true,
-    vibrationPreference: true
+    vibrationPreference: true,
+    highlights: true
   };
   private previousFocus: HTMLElement | null = null;
 
@@ -147,7 +149,8 @@ export default class Root extends Component<Props, State> {
 
       this.setState({
         motionPreference: await lazyImport!.shouldUseMotion(),
-        vibrationPreference: await lazyImport!.getVibrationPreference()
+        vibrationPreference: await lazyImport!.getVibrationPreference(),
+        highlights: await lazyImport!.getHighlights()
       });
     });
 
@@ -234,7 +237,8 @@ export default class Root extends Component<Props, State> {
       gameInPlay,
       bestTime,
       allowIntroAnim,
-      vibrationPreference
+      vibrationPreference,
+      highlights
     }: State
   ) {
     let mainComponent: VNode;
@@ -258,6 +262,8 @@ export default class Root extends Component<Props, State> {
                 texturePromise={texturePromise}
                 useVibration={vibrationPreference}
                 onVibrationPrefChange={this._onVibrationPrefChange}
+                onHighlightsChange={this._onHighlightsChange}
+                highlights={highlights}
               />
             )}
           />
@@ -371,6 +377,14 @@ export default class Root extends Component<Props, State> {
     this.setState({ vibrationPreference });
     const { setVibrationPreference } = await lazyImportReady;
     setVibrationPreference(vibrationPreference);
+  }
+
+  @bind
+  private async _onHighlightsChange() {
+    const highlights = !this.state.highlights;
+    this.setState({ highlights });
+    const { setHighlights } = await lazyImportReady;
+    setHighlights(highlights);
   }
 
   @bind

--- a/src/services/preact-canvas/lazy-load.ts
+++ b/src/services/preact-canvas/lazy-load.ts
@@ -17,6 +17,7 @@ import { lazyGenerateTextures } from "../../rendering/animation";
 import { supportsSufficientWebGL } from "../../rendering/renderer";
 import { nextEvent } from "../../utils/scheduling";
 import { getBest, submitTime } from "../state/best-times";
+import { getHighlights, setHighlights } from "../state/highlights-preference";
 import {
   getMotionPreference,
   setMotionPreference,
@@ -42,5 +43,7 @@ export {
   getMotionPreference,
   shouldUseMotion,
   getVibrationPreference,
-  setVibrationPreference
+  setVibrationPreference,
+  getHighlights,
+  setHighlights
 };

--- a/src/services/state/highlights-preference.ts
+++ b/src/services/state/highlights-preference.ts
@@ -1,0 +1,15 @@
+import { get, set } from "idb-keyval";
+
+const DEFAULT = true;
+
+export async function setHighlights(pref: boolean) {
+  await set("highlights", pref);
+}
+
+export async function getHighlights() {
+  const highlights = await get("highlights");
+  if (typeof highlights === "boolean") {
+    return highlights;
+  }
+  return DEFAULT;
+}


### PR DESCRIPTION
Added toggle to the Settings menu which allows you to turn off highlighting on the numbers (they don't turn blue when there are flags around them).

This serves as a cool feature for people who are looking for added difficulty and want PROXX to work more like the original Minesweeper.