### PR TITLE
Hold to flag with Nebula flash

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -452,8 +452,8 @@ export default class Board extends Component<Props, State> {
     }
 
     const activeButton = event.target as HTMLButtonElement;
-    const isActiveBtn = this._additionalButtonData.has(activeButton);
-    if (!isActiveBtn) {
+    const activeButtonData = this._additionalButtonData.get(activeButton);
+    if (!activeButtonData || activeButtonData[2].revealed) {
       return;
     }
 

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -81,6 +81,8 @@ export default class Board extends Component<Props, State> {
   private _tableContainer?: HTMLDivElement;
   private _touchScreen: boolean = false;
   private _holdState: HoldState | null = null;
+  private _afterHoldFlag: boolean = false;
+  private _firstClickAfterHold: boolean = false;
 
   componentDidMount() {
     document.documentElement.classList.add("in-game");
@@ -443,6 +445,12 @@ export default class Board extends Component<Props, State> {
       this._touchScreen = true;
     }
 
+    if (!this._firstClickAfterHold && this._afterHoldFlag) {
+      this._afterHoldFlag = false;
+    } else if (this._firstClickAfterHold) {
+      this._firstClickAfterHold = false;
+    }
+
     const activeButton = event.target as HTMLButtonElement;
     const isActiveBtn = this._additionalButtonData.has(activeButton);
     if (!isActiveBtn) {
@@ -477,6 +485,8 @@ export default class Board extends Component<Props, State> {
     this.simulateClick(this._holdState!.buttonPressed, true);
     this.props.afterHoldFlash();
     this._holdState = null;
+    this._afterHoldFlag = true;
+    this._firstClickAfterHold = true;
   }
 
   private _toggleDangerMode() {
@@ -485,6 +495,9 @@ export default class Board extends Component<Props, State> {
 
   @bind
   private onDblClick(event: MouseEvent) {
+    if (this._afterHoldFlag) {
+      return;
+    }
     if (event.target === this._tableContainer) {
       this._toggleDangerMode();
       return;

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -441,9 +441,7 @@ export default class Board extends Component<Props, State> {
   // Same as mouseup, necessary for preventing click event on KaiOS
   @bind
   private onTouchStart(event: TouchEvent) {
-    if (!this._touchScreen) {
-      this._touchScreen = true;
-    }
+    this._touchScreen = true;
 
     if (!this._firstClickAfterHold && this._afterHoldFlag) {
       this._afterHoldFlag = false;

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -474,7 +474,7 @@ export default class Board extends Component<Props, State> {
 
   @bind
   private secondaryAfterHold() {
-    this.simulateClick((this._holdState as HoldState).buttonPressed, true);
+    this.simulateClick(this._holdState!.buttonPressed, true);
     this.props.afterHoldFlash();
     this._holdState = null;
   }

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -48,6 +48,7 @@ export interface Props {
   gameChangeSubscribe: (f: GameChangeCallback) => void;
   gameChangeUnsubscribe: (f: GameChangeCallback) => void;
   onDangerModeChange: (v: boolean) => void;
+  afterHoldFlash: () => void;
 }
 
 interface State {
@@ -474,6 +475,7 @@ export default class Board extends Component<Props, State> {
   @bind
   private secondaryAfterHold() {
     this.simulateClick((this._holdState as HoldState).buttonPressed, true);
+    this.props.afterHoldFlash();
     this._holdState = null;
   }
 

--- a/src/services/preact-canvas/components/game/index.tsx
+++ b/src/services/preact-canvas/components/game/index.tsx
@@ -50,6 +50,7 @@ export interface Props {
   useMotion: boolean;
   bestTime?: number;
   useVibration: boolean;
+  afterHoldFlash: () => void;
 }
 
 interface State {
@@ -136,6 +137,7 @@ export default class Game extends Component<Props, State> {
               gameChangeUnsubscribe={gameChangeUnsubscribe}
               onCellClick={this.onCellClick}
               onDangerModeChange={this.props.onDangerModeChange}
+              afterHoldFlash={this.props.afterHoldFlash}
             />,
             playMode === PlayMode.Lost ? (
               <div class={exitRow}>

--- a/src/services/preact-canvas/components/nebula/index.tsx
+++ b/src/services/preact-canvas/components/nebula/index.tsx
@@ -87,6 +87,7 @@ export default class Nebula extends Component<Props, State> {
 
     this._prevColors = [this.props.colorLight, this.props.colorDark];
     this._colorBlend = 0;
+    this._fadeSpeed = 10;
   }
 
   componentDidUpdate(oldProps: Props) {
@@ -98,6 +99,7 @@ export default class Nebula extends Component<Props, State> {
       }
     }
     if (oldProps.flashTrigger !== this.props.flashTrigger) {
+      this._fadeSpeed = 15;
       this._flash();
       return;
     }

--- a/src/services/preact-canvas/components/nebula/index.tsx
+++ b/src/services/preact-canvas/components/nebula/index.tsx
@@ -35,9 +35,14 @@ export interface Props {
 
 const metaTheme = document.querySelector('meta[name="theme-color"]')!;
 
-interface State {}
+interface State {
+  noAnimationFlash: boolean;
+}
 
 export default class Nebula extends Component<Props, State> {
+  state: State = {
+    noAnimationFlash: false
+  };
   private _timePeriod = 60000;
   private _fadeSpeed = 10;
   private _colorBlend = 0;
@@ -53,12 +58,10 @@ export default class Nebula extends Component<Props, State> {
     window.addEventListener("resize", this._onResize);
   }
 
-  shouldComponentUpdate({
-    colorLight,
-    colorDark,
-    useMotion,
-    flashTrigger
-  }: Props) {
+  shouldComponentUpdate(
+    { colorLight, colorDark, useMotion, flashTrigger }: Props,
+    { noAnimationFlash }: State
+  ) {
     if (useMotion !== this.props.useMotion) {
       return true;
     }
@@ -67,7 +70,8 @@ export default class Nebula extends Component<Props, State> {
     return (
       didLightColorChange ||
       didDarkColorChange ||
-      this.props.flashTrigger !== flashTrigger
+      this.props.flashTrigger !== flashTrigger ||
+      this.state.noAnimationFlash !== noAnimationFlash
     );
   }
 
@@ -100,13 +104,22 @@ export default class Nebula extends Component<Props, State> {
     this._updateColors();
   }
 
-  render({ colorLight, colorDark, useMotion }: Props) {
+  render(
+    { colorLight, colorDark, useMotion, flashFromDark, flashFromLight }: Props,
+    { noAnimationFlash }: State
+  ) {
     return (
       <div
         class={nebulaContainer}
-        style={`background: linear-gradient(to bottom, ${toRGB(
-          colorLight
-        )}, ${toRGB(colorDark)}`}
+        style={
+          noAnimationFlash
+            ? `background: linear-gradient(to bottom, ${toRGB(
+                flashFromLight
+              )}, ${toRGB(flashFromDark)}`
+            : `background: linear-gradient(to bottom, ${toRGB(
+                colorLight
+              )}, ${toRGB(colorDark)}`
+        }
       >
         {useMotion && <canvas class={nebulaStyle} aria-hidden="true" />}
       </div>
@@ -183,24 +196,31 @@ export default class Nebula extends Component<Props, State> {
   }
 
   private _flash() {
-    const colorDark = this.props.colorDark;
+    if (this._loopRunning) {
+      const colorDark = this.props.colorDark;
 
-    if (!this._shaderBox) {
+      if (!this._shaderBox) {
+        return;
+      }
+      this._shaderBox.setUniform4f(
+        "main_color_light",
+        toShaderColor(this.props.flashFromLight)
+      );
+      this._shaderBox.setUniform4f(
+        "main_color_dark",
+        toShaderColor(this.props.flashFromDark)
+      );
+      this._shaderBox.setUniform4f(
+        "alt_color_light",
+        toShaderColor(this.props.colorLight)
+      );
+      this._shaderBox.setUniform4f("alt_color_dark", toShaderColor(colorDark));
       return;
     }
-    this._shaderBox.setUniform4f(
-      "main_color_light",
-      toShaderColor(this.props.flashFromLight)
-    );
-    this._shaderBox.setUniform4f(
-      "main_color_dark",
-      toShaderColor(this.props.flashFromDark)
-    );
-    this._shaderBox.setUniform4f(
-      "alt_color_light",
-      toShaderColor(this.props.colorLight)
-    );
-    this._shaderBox.setUniform4f("alt_color_dark", toShaderColor(colorDark));
+    this.setState({ noAnimationFlash: true });
+    setTimeout(() => {
+      this.setState({ noAnimationFlash: false });
+    }, 200);
   }
 
   private _start() {

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -343,9 +343,9 @@ export default class Root extends Component<Props, State> {
   private _nebulaLightColor() {
     if (this.state.canvas2dFlash) {
       if (this.state.dangerMode) {
-        return avgColors(nebulaDangerLight, nebulaSafeLight, 0.6);
+        return avgColors(nebulaDangerLight, nebulaSafeLight, 0.65);
       } else {
-        return avgColors(nebulaSafeLight, nebulaDangerLight, 0.6);
+        return avgColors(nebulaSafeLight, nebulaDangerLight, 0.65);
       }
     }
     if (this.state.settingsOpen) {
@@ -363,9 +363,9 @@ export default class Root extends Component<Props, State> {
   private _nebulaDarkColor() {
     if (this.state.canvas2dFlash) {
       if (this.state.dangerMode) {
-        return avgColors(nebulaDangerDark, nebulaSafeDark, 0.6);
+        return avgColors(nebulaDangerDark, nebulaSafeDark, 0.65);
       } else {
-        return avgColors(nebulaSafeDark, nebulaDangerDark, 0.6);
+        return avgColors(nebulaSafeDark, nebulaDangerDark, 0.65);
       }
     }
     if (this.state.settingsOpen) {
@@ -474,9 +474,7 @@ export default class Root extends Component<Props, State> {
 }
 
 function avgColors(c1: Color, c2: Color, ratio: number = 0.5) {
-  const c1Amount = ratio * 100;
-  const c2Amount = 100 - c1Amount;
   return c1.map((item, i) =>
-    Math.floor((item * c1Amount + c2[i] * c2Amount) / 100)
+    Math.round(item * ratio + c2[i] * (1 - ratio))
   ) as Color;
 }


### PR DESCRIPTION
NOW it solves issue #55... I think... well... I hope....

After user holds his finger on a tile for 400 ms, the alternate click gets executed (flags the tile in danger mode, reveals it in safe mode). At the same time, the background flashes with a color of the other mode (I was originally testing it with white flash but I found it to be way too distracting).

If Nebula is enabled, the color switches e.g. from red to blue immediately and then it slowly fades back to red. The flash gets triggered by flipping a value of the "flashTrigger" prop on the Nebula component.

If animations are disabled, the background gradient momentarily switches to a blend of both colors and after 200 ms it switches back.