### PR TITLE
Add basic security via response headers

### DIFF
--- a/src/_headers
+++ b/src/_headers
@@ -1,3 +1,11 @@
+# Basic security.
+/*
+  Referrer-Policy: no-referrer-when-downgrade
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  X-XSS-Protection: 1; mode=block
+
 # Long-term cache by default.
 /*
   Cache-Control: max-age=31536000


### PR DESCRIPTION
This change configures response headers for basic security.

The following headers are configured (as explained by [securityheaders.com](https://securityheaders.com/):

* [X-Frame-Options](https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options) tells the browser whether you want to allow your site to be framed or not. By preventing a browser from framing your site you can defend against attacks like clickjacking. Recommended value "X-Frame-Options: SAMEORIGIN".
* [X-Content-Type-Options](https://scotthelme.co.uk/hardening-your-http-response-headers/#x-content-type-options) stops a browser from trying to MIME-sniff the content type and forces it to stick with the declared content-type. The only valid value for this header is "X-Content-Type-Options: nosniff".
* [Referrer Policy](https://scotthelme.co.uk/a-new-security-header-referrer-policy/) is a new header that allows a site to control how much information the browser includes with navigations away from a document and should be set by all sites.

**Before:**
![D-rating on Security Headers](https://user-images.githubusercontent.com/1516059/62421139-4c6f6400-b69d-11e9-8e60-231344c925a4.jpg)
source: https://securityheaders.com/?q=https%3A%2F%2Fproxx.app%2F&hide=on&followRedirects=on

**After:**
![B-rating on Security Headers](https://user-images.githubusercontent.com/1516059/62421184-1979a000-b69e-11e9-9fe0-c174b7cd26d8.jpg)
source: https://securityheaders.com/?q=https%3A%2F%2Fdeploy-preview-492--gravitongame.netlify.com%2F&hide=on&followRedirects=on

Note security could be tightened further by configuring [Content Security Policy](https://scotthelme.co.uk/content-security-policy-an-introduction/) and [Feature Policy](https://scotthelme.co.uk/a-new-security-header-feature-policy/). 