### PR TITLE
Load the GA script after all elements have been loaded.

### DIFF
--- a/src/main/bootstrap.tsx
+++ b/src/main/bootstrap.tsx
@@ -26,8 +26,10 @@ if (!prerender) {
   ga("create", "UA-139146337-1", "auto");
   ga("set", "transport", "beacon");
   ga("send", "pageview");
-  // Load the GA script
-  const s = document.createElement("script");
-  s.src = "https://www.google-analytics.com/analytics.js";
-  document.head!.appendChild(s);
+  // Load the GA script after all elements have been loaded.
+  window.addEventListener("load", () => {
+    const s = document.createElement("script");
+    s.src = "https://www.google-analytics.com/analytics.js";
+    document.head!.appendChild(s);
+  });
 }


### PR DESCRIPTION
After having watched https://www.youtube.com/watch?v=TsTt7Tja30Q, I figured I should try to improve PROXX perf as well. So here are my 2 cents.

Let's load the GA script after all elements (including lazy load scripts) have been loaded. It obviously improves Load time (not that important) but also improves DOMContentLoaded time.

WDYT?