### PR TITLE
Add missing aria-level attribute

### DIFF
--- a/src/main/services/preact-canvas/components/showbiz-title/index.tsx
+++ b/src/main/services/preact-canvas/components/showbiz-title/index.tsx
@@ -125,6 +125,7 @@ export default class ShowbizTitle extends Component<Props, State> {
       <div
         class={`${showbizTitle} ${motion ? animateStyle : ""}`}
         role="heading"
+        aria-level="1"
         aria-label="PROXX"
       >
         <div class={showbizTitleFrame} aria-hidden="true">


### PR DESCRIPTION
If `role=heading`, then `aria-level` attribute is required according to lighthouse. This PR fixes this.