### PR TITLE
insert canvas behind scrollbars

### DIFF
--- a/src/main/services/preact-canvas/components/board/index.tsx
+++ b/src/main/services/preact-canvas/components/board/index.tsx
@@ -206,7 +206,7 @@ export default class Board extends Component<Props, State> {
     }
     this._canvas = this.props.renderer.createCanvas();
     this._canvas.classList.add(canvasStyle);
-    this.base!.appendChild(this._canvas);
+    this.base!.insertBefore(this._canvas, tableContainer); // tableContainer has scrollbars so canvas is under
     tableContainer!.appendChild(this._table);
     this._table.addEventListener("keydown", this.onKeyDownOnTable);
     this._table.addEventListener("keyup", this.onKeyUpOnTable);


### PR DESCRIPTION
this is a fix for issue #499

on losing; the bombs would appear above the right scrollbar. this happened because the canvas holding the bombs was appended after the `tableContainer` element which holds the scrollbars. this PR inserts the canvas before `tableContainer`