### PR TITLE
Automate prevention of accidentally increasing entry bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5402,6 +5402,12 @@
         "rollup-pluginutils": "^2.3.0"
       }
     },
+    "rollup-plugin-bundle-guard": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-guard/-/rollup-plugin-bundle-guard-2.2.0.tgz",
+      "integrity": "sha512-8Kubivpz0Ueob1+VIQDTHN1A7txE7yKPr19N6PtP+6hP4/kR94JoCsLmRqtHqoZUZm99M+Z3p6luzJuoyE+r6Q==",
+      "dev": true
+    },
     "rollup-plugin-loadz0r": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-loadz0r/-/rollup-plugin-loadz0r-0.7.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5395,9 +5395,9 @@
       }
     },
     "rollup-plugin-bundle-guard": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-guard/-/rollup-plugin-bundle-guard-2.2.0.tgz",
-      "integrity": "sha512-8Kubivpz0Ueob1+VIQDTHN1A7txE7yKPr19N6PtP+6hP4/kR94JoCsLmRqtHqoZUZm99M+Z3p6luzJuoyE+r6Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-guard/-/rollup-plugin-bundle-guard-2.2.1.tgz",
+      "integrity": "sha512-+k//0sNGEA9NMHeIg6IUCZCpEURKgK1v4wUYDPfa5OJFFbQORMyAiltiiqTvvXjN36cnaGaQeo4x8K1b74o1fA==",
       "dev": true
     },
     "rollup-plugin-loadz0r": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,9 +809,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "agent-base": {
@@ -5374,22 +5374,14 @@
       }
     },
     "rollup": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.16.2.tgz",
-      "integrity": "sha512-UAZxaQvH0klYZdF+90xv9nGb+m4p8jdoaow1VL5/RzDK/gN/4CjvaMmJNcOIv1/+gtzswKhAg/467mzF0sLpAg==",
+      "version": "1.27.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.4.tgz",
+      "integrity": "sha512-UaGNOIax/Ixfd92CAAanUilx2RSkkwEfC1lCTw1eL5Re6NURWgX66ARZt5+3px4kYnpSwzyOot4r18c2b+QgJQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "^12.0.8",
-        "acorn": "^6.1.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.0.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
-          "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
-          "dev": true
-        }
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
       }
     },
     "rollup-plugin-babel": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^1.15.2",
     "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-bundle-guard": "^2.2.0",
     "rollup-plugin-loadz0r": "^0.7.2",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-postcss": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^1.27.4",
     "rollup-plugin-babel": "^4.3.2",
-    "rollup-plugin-bundle-guard": "^2.2.0",
+    "rollup-plugin-bundle-guard": "^2.2.1",
     "rollup-plugin-loadz0r": "^0.7.2",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-postcss": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier": "^1.17.0",
     "puppeteer": "^1.14.0",
     "rimraf": "^2.6.2",
-    "rollup": "^1.15.2",
+    "rollup": "^1.27.4",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-bundle-guard": "^2.2.0",
     "rollup-plugin-loadz0r": "^0.7.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,7 @@
 import nodeResolve from "rollup-plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
 import loadz0r from "rollup-plugin-loadz0r";
+import rollupPluginBundleGuard from "rollup-plugin-bundle-guard";
 import chunkNamePlugin from "./lib/chunk-name-plugin";
 import resourceListPlugin from "./lib/resource-list-plugin";
 import postcss from "rollup-plugin-postcss";
@@ -108,6 +109,20 @@ function buildConfig({ prerender, watch } = {}) {
       }),
       chunkNamePlugin(),
       nodeResolve(),
+      rollupPluginBundleGuard({
+        modules: [
+          { module: /^consts:/, allowedImportFrom: ["entry", "swEntry"] },
+          { module: "tslib", allowedImportFrom: ["entry", "swEntry"] },
+          { module: /^chunk-name:/, allowedImportFrom: ["entry"] },
+          { module: "preact", allowedImportFrom: ["entry"] },
+          { module: /\.css$/, allowedImportFrom: ["entry"] },
+          { module: "idb-keyval", allowedImportFrom: ["entry"] },
+          {
+            module: /^resource-list:/,
+            allowedImportFrom: ["swEntry"]
+          }
+        ]
+      }),
       loadz0r({
         loader: readFileSync("./lib/loadz0r-loader.ejs").toString(),
         // `prependLoader` will be called for every chunk. If it returns `true`,

--- a/src/main/bootstrap.tsx
+++ b/src/main/bootstrap.tsx
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 
+// rollup-plugin-bundle-guard: group=entry
+
 import prerender from "consts:prerender";
 import { h, render } from "preact";
 import Root from "src/main/services/preact-canvas";

--- a/src/main/services/preact-canvas/components/bottom-bar/index.tsx
+++ b/src/main/services/preact-canvas/components/bottom-bar/index.tsx
@@ -32,6 +32,7 @@ import {
 } from "./style.css";
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 function goFullscreen() {
   if (document.documentElement.requestFullscreen) {

--- a/src/main/services/preact-canvas/components/deferred/index.tsx
+++ b/src/main/services/preact-canvas/components/deferred/index.tsx
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 import { Component, ComponentConstructor, VNode } from "preact";
 

--- a/src/main/services/preact-canvas/components/game-loading/index.tsx
+++ b/src/main/services/preact-canvas/components/game-loading/index.tsx
@@ -14,6 +14,7 @@ import { Component, h } from "preact";
 import { loading, loadingInner } from "./style.css";
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 export default class GameLoading extends Component<{}, {}> {
   render() {

--- a/src/main/services/preact-canvas/components/icons/initial.tsx
+++ b/src/main/services/preact-canvas/components/icons/initial.tsx
@@ -13,6 +13,7 @@
 import { h } from "preact";
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 // tslint:disable:max-line-length variable-name
 

--- a/src/main/services/preact-canvas/components/intro/index.tsx
+++ b/src/main/services/preact-canvas/components/intro/index.tsx
@@ -41,6 +41,7 @@ import {
 type GridType = import("../../../preact-canvas").GridType;
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 // tslint:disable-next-line: variable-name
 const ShowbizTitleDeferred = deferred(

--- a/src/main/services/preact-canvas/index.tsx
+++ b/src/main/services/preact-canvas/index.tsx
@@ -10,6 +10,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
+
 import workerURL from "chunk-name:./../../../worker";
 import nebulaSafeDark from "consts:nebulaSafeDark";
 import prerender from "consts:prerender";
@@ -29,8 +33,6 @@ import { game as gameClassName, nebulaContainer } from "./style.css";
 type Color = import("src/main/rendering/constants").Color;
 type GameStateChange = import("../../../worker/gamelogic").StateChange;
 type GameType = import("../../../worker/state-service").GameType;
-
-// WARNING: This module is part of the main bundle. Avoid adding to it if possible.
 
 let lazyImport: typeof import("./lazy-load") | undefined;
 const lazyImportReady = import("./lazy-load").then(m => (lazyImport = m));

--- a/src/main/services/state/grid-default.ts
+++ b/src/main/services/state/grid-default.ts
@@ -16,6 +16,7 @@ import { GridType } from "../preact-canvas";
 import { presets } from "./grid-presets";
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 const key = "default-game";
 

--- a/src/main/services/state/grid-presets.ts
+++ b/src/main/services/state/grid-presets.ts
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 export const presets = {
   easy: { width: 8, height: 8, mines: 10 },

--- a/src/main/services/state/local-state-subscribe.ts
+++ b/src/main/services/state/local-state-subscribe.ts
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 export default async function localStateSubscribe(
   stateService: import("comlink/src/comlink").Remote<

--- a/src/main/utils/constants.ts
+++ b/src/main/utils/constants.ts
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 const url = new URL(location.href);
 

--- a/src/main/utils/static-display.ts
+++ b/src/main/utils/static-display.ts
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 import { fpmode } from "./constants";
 

--- a/src/main/utils/to-rgb.ts
+++ b/src/main/utils/to-rgb.ts
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 export default function toRGB(
   color: import("src/main/rendering/constants").Color

--- a/src/sw/index.ts
+++ b/src/sw/index.ts
@@ -1,3 +1,5 @@
+// rollup-plugin-bundle-guard: group=swEntry
+
 import version from "consts:version";
 import resourceList from "resource-list:";
 // Give TypeScript the correct global.

--- a/src/utils/bind.ts
+++ b/src/utils/bind.ts
@@ -12,6 +12,7 @@
  */
 
 // WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+// rollup-plugin-bundle-guard: group=entry
 
 export function bind(
   _target: any,


### PR DESCRIPTION
I watched your [jsconf presentation on making things fast](https://www.youtube.com/watch?v=fWc3Zu6A3Ws) (which was great by the way) and towards the end you mentioned including warning comments to try and prevent accidentally importing something into the entry bundle.

I thought there must be a way of automating this, so that the comments could actually enforce it, and put together [a rollup plugin](https://github.com/tjenkinson/rollup-plugin-bundle-guard) 

Interested to know what you think

The result of this PR is if you try and import something from a module that is in the `entry` group, that is not itself in the `entry` group (or an exception in the config), it will error out.