### PR TITLE
disable typescript automatically bringing in @types packages

### DIFF
--- a/generic-tsconfig.json
+++ b/generic-tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react",
     "jsxFactory": "h",
     "strict": true,
+    "types": [],
     "moduleResolution": "node",
     "outDir": ".ts-tmp",
     "composite": true,


### PR DESCRIPTION
see https://github.com/rollup/rollup/pull/3226#issuecomment-552580538

rollup brings in types for node, which are then automatically registered, and mean typecript won't error if you use an API that is only available in node