### PR TITLE
Add ease-of-use keybindings for keyboard and left-handed users

### DIFF
--- a/src/main/services/preact-canvas/components/board/index.tsx
+++ b/src/main/services/preact-canvas/components/board/index.tsx
@@ -363,8 +363,9 @@ export default class Board extends Component<Props, State> {
   private onKeyDownOnTable(event: KeyboardEvent) {
     // Since click action is tied to mouseup event,
     // listen to Enter in case of key navigation click.
-    // Key 8 support is for T9 navigation
-    if (event.key === "Enter" || event.key === "8") {
+    // Key 8 support is for T9 navigation.
+    // Space key support provides ease-of-use for keyboard users.
+    if (event.key === "Enter" || event.key === "8" || event.key === " ") {
       const button = document.activeElement as HTMLButtonElement;
       if (!button) {
         return;

--- a/src/main/services/preact-canvas/components/board/index.tsx
+++ b/src/main/services/preact-canvas/components/board/index.tsx
@@ -155,7 +155,11 @@ export default class Board extends Component<Props, State> {
         event.key === "ArrowLeft" ||
         event.key === "ArrowRight" ||
         event.key === "ArrowUp" ||
-        event.key === "ArrowDown")
+        event.key === "ArrowDown" || 
+        event.key === "a" || 
+        event.key === "d" || 
+        event.key === "w" || 
+        event.key === "s")
     ) {
       this.moveFocusByKey(event, 0, 0);
     }
@@ -372,13 +376,13 @@ export default class Board extends Component<Props, State> {
       }
       event.preventDefault();
       this.simulateClick(button);
-    } else if (event.key === "ArrowRight" || event.key === "9") {
+    } else if (event.key === "ArrowRight" || event.key === "9" || event.key === "d") {
       this.moveFocusByKey(event, 1, 0);
-    } else if (event.key === "ArrowLeft" || event.key === "7") {
+    } else if (event.key === "ArrowLeft" || event.key === "7" || event.key === "a") {
       this.moveFocusByKey(event, -1, 0);
-    } else if (event.key === "ArrowUp" || event.key === "5") {
+    } else if (event.key === "ArrowUp" || event.key === "5" || event.key === "w") {
       this.moveFocusByKey(event, 0, -1);
-    } else if (event.key === "ArrowDown" || event.key === "0") {
+    } else if (event.key === "ArrowDown" || event.key === "0" || event.key === "s") {
       this.moveFocusByKey(event, 0, 1);
     }
   }

--- a/src/main/services/preact-canvas/components/bottom-bar/index.tsx
+++ b/src/main/services/preact-canvas/components/bottom-bar/index.tsx
@@ -220,7 +220,7 @@ export default class BottomBar extends Component<Props, State> {
       }
     } else if (
       this.props.showDangerModeToggle &&
-      (event.key === "f" || event.key === "#")
+      (event.key === "f" || event.key === "#" || event.key === "m")
     ) {
       this._dangerModeChange(!this.props.dangerMode, true);
     }


### PR DESCRIPTION
PROXX so far has a lot of ease-of-use shortcuts to support desktop users. Things like using the F key to change the mode, using the arrow keys to navigate the board, and using the Enter key to click cells. However, it is pretty awkward for users who want to play the game using only a keyboard to do so; for example, on a U.S. keyboard, the Enter key is miles away from the F key, therefore requiring the user to either stretch their hand for a prolonged period of time, or position their fingers on both the f and 8 keys (which is a really unusual position for most keyboard users, especially the ones who use the Home-row typing strategy). The situation is a bit less awkward for users with a U.K keyboard due to the fact that the hashtag key is right next to the Enter key; however, that requires the user to place their left hand on the Enter and hashtag keys, while placing their right hand on the arrow keys, therefore causing both hands to overlap. This issue gets even worse on laptops because the arrow keys are significantly closer to the Enter key.

The solution, therefore, is to allow the Space key to be used to click on cells. This will please both the users who use the Home-row typing strategy (by placing their left hand normally (i.e. on the F key) and using their thumb to click on space) and the users who are used to traditional gaming keybinds (they will need to, however, get used to placing their hand on the F key instead of WASD, but that's definitely much easier to get used to than the F&8 position).

Additionally, keyboard users whose dominant hand is their left one might find it difficult to use the arrow keys when compared to the WASD keys. This also applies, to a lesser extent, to users who are used to the WASD keys as a way to move around in games. Adding support for these keys will provide fast and reliable movements for keyboard users who are trying to get a new high score, or just regular users who want to play for a prolonged period of time without having their non-dominant hand hurt.

As a result of adding support for WASD, PROXX needs to add an easy way for keyboard users to use their right hand for changing the flag mode and for clicking cells. Adding support for the Space key fixes the latter problem. For the former, though, the current keybinds don't work on the U.S. keyboard because the F key is hard to reach with one's right hand (and even if a user decides to do so, it'll cause overlap between that hand and their left hand (which is on the WASD keys). This isn't a problem on the U.K. keyboard, however, since the hashtag key is right next to the Enter key, but supporting the U.S. users is still crucial. Using the M key to change the *M*ode makes a lot of sense, and it would allow a seamless experience for users.

TL;DR: this PR adds Space, M, and WASD as a way to click cells, change the flag mode, and move around the board respectively. This is to provide comfortable keyboard positions for desktop users.