### PR TITLE
Add gamepad support

### DIFF
--- a/src/main/missing-types.d.ts
+++ b/src/main/missing-types.d.ts
@@ -29,3 +29,52 @@ declare namespace JSX {
     inputmode?: string;
   }
 }
+
+/**
+ * This Gamepad API interface defines an individual gamepad or other controller, allowing access to
+ * information such as button presses, axis positions, and id. Available only in secure contexts.
+ */
+interface Gamepad {
+  readonly axes: ReadonlyArray<number>;
+  readonly buttons: ReadonlyArray<GamepadButton>;
+  readonly connected: boolean;
+  readonly hapticActuators: ReadonlyArray<GamepadHapticActuator>;
+  readonly id: string;
+  readonly index: number;
+  readonly mapping: GamepadMappingType;
+  readonly timestamp: DOMHighResTimeStamp;
+}
+
+declare var Gamepad: {
+  prototype: Gamepad;
+  new (): Gamepad;
+};
+
+/**
+ * An individual button of a gamepad or other controller, allowing access to the current state of
+ * different types of buttons available on the control device. Available only in secure contexts.
+ */
+interface GamepadButton {
+  readonly pressed: boolean;
+  readonly touched: boolean;
+  readonly value: number;
+}
+
+declare var GamepadButton: {
+  prototype: GamepadButton;
+  new (): GamepadButton;
+};
+
+/**
+ * This Gamepad API interface contains references to gamepads connected to the system, which is what
+ * the gamepad events Window.gamepadconnected and Window.gamepaddisconnected are fired in response to.
+ * Available only in secure contexts.
+ */
+interface GamepadEvent extends Event {
+  readonly gamepad: Gamepad;
+}
+
+declare var GamepadEvent: {
+  prototype: GamepadEvent;
+  new (type: string, eventInitDict: GamepadEventInit): GamepadEvent;
+};

--- a/src/main/services/preact-canvas/components/game/style.css
+++ b/src/main/services/preact-canvas/components/game/style.css
@@ -78,3 +78,15 @@
   /** PostCSS adding classes in wrong order :( */
   border-color: #000 !important;
 }
+
+.gamepad-button {
+  composes: gamepadbutton from "../../utils.css";
+}
+
+.gamepad-button-a {
+  color: var(--color-gamepad-a);
+}
+
+.gamepad-button-b {
+  color: var(--color-gamepad-b);
+}

--- a/src/main/services/preact-canvas/components/intro/index.tsx
+++ b/src/main/services/preact-canvas/components/intro/index.tsx
@@ -17,12 +17,14 @@ import {
   PresetName,
   presets
 } from "src/main/services/state/grid-presets";
+import { gamepad } from "src/main/utils/gamepad";
 import { isFeaturePhone } from "src/main/utils/static-display";
 import { bind } from "src/utils/bind";
 import deferred from "../deferred";
 import { Arrow } from "../icons/initial";
 import {
   field as fieldStyle,
+  gamepadButton as gamepadButtonStyle,
   intro as introStyle,
   label as labelStyle,
   labelText as labelTextStyle,
@@ -120,6 +122,7 @@ export interface Props {
   onStartGame: (width: number, height: number, mines: number) => void;
   defaults?: GridType;
   motion: boolean;
+  isGamepadConnected: boolean;
 }
 
 interface State {
@@ -146,10 +149,12 @@ export default class Intro extends Component<Props, State> {
   componentDidMount() {
     window.scrollTo(0, 0);
     window.addEventListener("keyup", this._onKeyUp);
+    gamepad.addButtonDownCallback(this._onGamepadButtonDown);
   }
 
   componentWillUnmount() {
     window.removeEventListener("keyup", this._onKeyUp);
+    gamepad.removeButtonDownCallback(this._onGamepadButtonDown);
   }
 
   componentWillReceiveProps({ defaults }: Props) {
@@ -158,7 +163,10 @@ export default class Intro extends Component<Props, State> {
     }
   }
 
-  render({ motion }: Props, { width, height, mines, presetName }: State) {
+  render(
+    { motion, isGamepadConnected }: Props,
+    { width, height, mines, presetName }: State
+  ) {
     return (
       <div class={introStyle}>
         <div class={showbizIntroStyle}>
@@ -233,6 +241,11 @@ export default class Intro extends Component<Props, State> {
           <div class={settingsRowStyle}>
             <button class={startButtonStyle}>
               {isFeaturePhone ? <span class={shortcutKeyStyle}>#</span> : ""}{" "}
+              {isGamepadConnected ? (
+                <span class={gamepadButtonStyle}>A</span>
+              ) : (
+                ""
+              )}{" "}
               Start
             </button>
           </div>
@@ -245,6 +258,14 @@ export default class Intro extends Component<Props, State> {
   private _onKeyUp(event: KeyboardEvent) {
     if (event.key === "#") {
       this._startGame(event);
+    }
+  }
+
+  @bind
+  private _onGamepadButtonDown(buttonId: number) {
+    if (buttonId === 0) {
+      // A
+      this._startGame(new Event(""));
     }
   }
 

--- a/src/main/services/preact-canvas/components/intro/style.css
+++ b/src/main/services/preact-canvas/components/intro/style.css
@@ -161,3 +161,8 @@
   /** PostCSS adding classes in wrong order :( */
   border-color: #000 !important;
 }
+
+.gamepad-button {
+  composes: gamepadbutton from "../../utils.css";
+  color: var(--color-gamepad-a);
+}

--- a/src/main/services/preact-canvas/components/win/index.tsx
+++ b/src/main/services/preact-canvas/components/win/index.tsx
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 import { Component, h } from "preact";
+import { gamepad } from "src/main/utils/gamepad";
 import { bind } from "../../../../../utils/bind";
 import { minSec } from "../../../../utils/format";
 import { isFeaturePhone } from "../../../../utils/static-display";
@@ -19,6 +20,9 @@ import { Timer } from "../icons/additional";
 import {
   againButton,
   againShortcutKey,
+  gamepadButton,
+  gamepadButtonA,
+  gamepadButtonB,
   gridName as gridNameStyle,
   mainButton,
   noMotion,
@@ -43,6 +47,7 @@ interface Props {
   height: number;
   mines: number;
   useMotion: boolean;
+  isGamepadConnected: boolean;
 }
 
 interface State {
@@ -95,15 +100,17 @@ export default class End extends Component<Props, State> {
       window.scrollTo(0, 0);
     }, 0);
     this._playAgainBtn!.focus();
-    window.addEventListener("keyup", this.onKeyUp);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("keyup", this.onKeyUp);
   }
 
   render(
-    { onRestart, onMainMenu, time, bestTime, useMotion }: Props,
+    {
+      onRestart,
+      onMainMenu,
+      time,
+      bestTime,
+      useMotion,
+      isGamepadConnected
+    }: Props,
     { gridName }: State
   ) {
     const timeStr = minSec(time);
@@ -146,22 +153,24 @@ export default class End extends Component<Props, State> {
             {isFeaturePhone && (
               <span class={[shortcutKey, againShortcutKey].join(" ")}>#</span>
             )}{" "}
+            {isGamepadConnected ? (
+              <span class={[gamepadButton, gamepadButtonA].join(" ")}>A</span>
+            ) : (
+              ""
+            )}{" "}
             Play again
           </button>
           <button class={mainButton} onClick={onMainMenu}>
-            {isFeaturePhone ? <span class={shortcutKey}>*</span> : ""} Main menu
+            {isFeaturePhone ? <span class={shortcutKey}>*</span> : ""}
+            {isGamepadConnected ? (
+              <span class={[gamepadButton, gamepadButtonB].join(" ")}>B</span>
+            ) : (
+              ""
+            )}{" "}
+            Main menu
           </button>
         </div>
       </div>
     );
-  }
-
-  @bind
-  private onKeyUp(event: KeyboardEvent) {
-    if (event.key === "#") {
-      this.props.onRestart();
-    } else if (event.key === "*") {
-      this.props.onMainMenu();
-    }
   }
 }

--- a/src/main/services/preact-canvas/components/win/style.css
+++ b/src/main/services/preact-canvas/components/win/style.css
@@ -176,3 +176,15 @@
   /** PostCSS adding classes in wrong order :( */
   border-color: #000 !important;
 }
+
+.gamepad-button {
+  composes: gamepadbutton from "../../utils.css";
+}
+
+.gamepad-button-a {
+  color: var(--color-gamepad-a);
+}
+
+.gamepad-button-b {
+  color: var(--color-gamepad-b);
+}

--- a/src/main/services/preact-canvas/index.tsx
+++ b/src/main/services/preact-canvas/index.tsx
@@ -14,6 +14,7 @@ import workerURL from "chunk-name:./../../../worker";
 import nebulaSafeDark from "consts:nebulaSafeDark";
 import prerender from "consts:prerender";
 import { Component, h, VNode } from "preact";
+import { gamepad } from "src/main/utils/gamepad";
 import toRGB from "src/main/utils/to-rgb";
 import { bind } from "src/utils/bind";
 import { PlayMode } from "src/worker/gamelogic/types";
@@ -107,6 +108,7 @@ interface State {
   gameInPlay: boolean;
   allowIntroAnim: boolean;
   vibrationPreference: boolean;
+  isGamepadConnected: boolean;
 }
 
 export type GameChangeCallback = (stateChange: GameStateChange) => void;
@@ -133,7 +135,8 @@ export default class Root extends Component<Props, State> {
     motionPreference: true,
     gameInPlay: false,
     allowIntroAnim: true,
-    vibrationPreference: true
+    vibrationPreference: true,
+    isGamepadConnected: gamepad.isGamepadConnected
   };
   private previousFocus: HTMLElement | null = null;
 
@@ -234,6 +237,11 @@ export default class Root extends Component<Props, State> {
     if (prerender) {
       prerenderDone();
     }
+    gamepad.addConnectedCallback(this._onGamepadConnected);
+  }
+
+  componentWillUnmount() {
+    gamepad.removeConnectedCallback(this._onGamepadConnected);
   }
 
   render(
@@ -248,7 +256,8 @@ export default class Root extends Component<Props, State> {
       gameInPlay,
       bestTime,
       allowIntroAnim,
-      vibrationPreference
+      vibrationPreference,
+      isGamepadConnected
     }: State
   ) {
     let mainComponent: VNode;
@@ -280,6 +289,7 @@ export default class Root extends Component<Props, State> {
             onStartGame={this._onStartGame}
             defaults={prerender ? undefined : gridDefaults}
             motion={motionPreference && allowIntroAnim}
+            isGamepadConnected={isGamepadConnected}
           />
         );
       }
@@ -303,6 +313,7 @@ export default class Root extends Component<Props, State> {
               useMotion={motionPreference}
               bestTime={bestTime}
               useVibration={vibrationPreference}
+              isGamepadConnected={isGamepadConnected}
             />
           )}
         />
@@ -343,6 +354,11 @@ export default class Root extends Component<Props, State> {
         />
       </div>
     );
+  }
+
+  @bind
+  private _onGamepadConnected() {
+    this.setState({ isGamepadConnected: gamepad.isGamepadConnected });
   }
 
   private _nebulaLightColor() {

--- a/src/main/services/preact-canvas/utils.css
+++ b/src/main/services/preact-canvas/utils.css
@@ -66,6 +66,20 @@
   box-sizing: border-box;
 }
 
+.gamepadbutton {
+  border: solid 1px #fff;
+  background-color: #000;
+  font-weight: bold;
+  border-radius: 100%;
+  display: inline-block;
+  width: calc(var(--gamepadbtn-size) + 2px);
+  height: calc(var(--gamepadbtn-size) + 2px);
+  line-height: var(--gamepadbtn-size);
+  text-align: center;
+  letter-spacing: 0;
+  box-sizing: border-box;
+}
+
 .button {
   mix-blend-mode: screen;
 }

--- a/src/main/style.css
+++ b/src/main/style.css
@@ -20,10 +20,14 @@ html {
   --cell-padding: 2px;
   --side-margin: 10px;
   --icon-size: 20px;
+  --gamepadbtn-size: 20px;
   --circlebtn-size: 24px;
   --bar-avoid: 40px;
   --bar-padding: 5px;
   --border-radius: 7px;
+
+  --color-gamepad-a: #3cdb4e;
+  --color-gamepad-b: #d04242;
 }
 
 /* We're assuming (totally safe, right?) that widths below 320 are feature phones */
@@ -34,6 +38,7 @@ html {
     --cell-padding: 5px;
     --side-margin: 24px;
     --icon-size: 24px;
+    --gamepadbtn-size: 28px;
     --circlebtn-size: 48px;
     --bar-avoid: 78px;
     --bar-padding: 18px;

--- a/src/main/utils/gamepad.ts
+++ b/src/main/utils/gamepad.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { bind } from "src/utils/bind";
+
+// WARNING: This module is part of the main bundle. Avoid adding to it if possible.
+
+export interface GamepadState {
+  // For each button, how many ticks it has been held down for.
+  buttonsHeldTicks: number[];
+}
+
+export class GamepadController {
+  get isGamepadConnected(): boolean {
+    return this._hasConnectedGamepads;
+  }
+  private _state: GamepadState[] = [];
+
+  private _hasConnectedGamepads = false;
+  private _tickScheduled = false;
+
+  private _buttonDownCallbacks = new Set<(button: number) => void>();
+  private _buttonPressCallbacks = new Set<(button: number) => void>();
+  private _connectedCallbacks = new Set<() => void>();
+
+  constructor() {
+    // @ts-ignore This version of TS is not aware of this event.
+    window.addEventListener("gamepadconnected", this._onGamepadConnected);
+    this._scheduleTick();
+  }
+
+  addButtonDownCallback(callback: (button: number) => void) {
+    this._buttonDownCallbacks.add(callback);
+  }
+
+  removeButtonDownCallback(callback: (button: number) => void) {
+    this._buttonDownCallbacks.delete(callback);
+  }
+
+  addButtonPressCallback(callback: (button: number) => void) {
+    this._buttonPressCallbacks.add(callback);
+  }
+
+  removeButtonPressCallback(callback: (button: number) => void) {
+    this._buttonPressCallbacks.delete(callback);
+  }
+
+  addConnectedCallback(callback: () => void) {
+    this._connectedCallbacks.add(callback);
+  }
+
+  removeConnectedCallback(callback: () => void) {
+    this._connectedCallbacks.delete(callback);
+  }
+
+  @bind
+  private _onGamepadConnected() {
+    this._scheduleTick();
+  }
+
+  private _scheduleTick() {
+    if (!this._tickScheduled) {
+      this._tickScheduled = true;
+      requestAnimationFrame(this._tick);
+    }
+  }
+
+  @bind
+  private _tick() {
+    this._tickScheduled = false;
+    if (typeof navigator.getGamepads === "undefined") {
+      return;
+    }
+    const gamepads = navigator.getGamepads();
+
+    // Iterate over all gamepads, and update the state.
+    const currentlyIsConnected = this._hasConnectedGamepads;
+    this._hasConnectedGamepads = false;
+    for (let i = 0; i < gamepads.length; i++) {
+      const gamepad = gamepads[i];
+      if (gamepad !== null) {
+        this._hasConnectedGamepads = true;
+        let state = this._state[i];
+        if (state === undefined) {
+          state = this._state[i] = {
+            buttonsHeldTicks: new Array(gamepad.buttons.length).fill(0)
+          };
+        }
+
+        for (let j = 0; j < gamepad.buttons.length; j++) {
+          const button = gamepad.buttons[j];
+          if (button.pressed) {
+            state.buttonsHeldTicks[j]++;
+          } else {
+            state.buttonsHeldTicks[j] = 0;
+          }
+        }
+      }
+    }
+
+    if (currentlyIsConnected !== this._hasConnectedGamepads) {
+      this._connectedCallbacks.forEach(callback => callback());
+    }
+
+    // Iterate over all gamepads, and emit "buttonPress" and "buttonup" events.
+    for (const state of this._state) {
+      for (let j = 0; j < state.buttonsHeldTicks.length; j++) {
+        // If the button just started being pressed we emit a "down" and a "hold"
+        // event.
+        const tick = state.buttonsHeldTicks[j];
+        if (tick === 1) {
+          this._buttonDownCallbacks.forEach(callback => callback(j));
+        }
+        // If the button is being held down, we emit an event every 5 ticks
+        // (16.6 * 5 =~ 80ms) after an initial wait of 18 ticks
+        // (16.6 * 18 =~ 300ms). We also emit
+        if (tick === 1 || (tick >= 18 && (tick - 18) % 5 === 0)) {
+          this._buttonPressCallbacks.forEach(callback => {
+            callback(j);
+          });
+        }
+      }
+    }
+
+    // Schedule the next tick if there are still gamepads connected.
+    if (this._hasConnectedGamepads) {
+      this._scheduleTick();
+    }
+  }
+}
+
+export const gamepad = new GamepadController();


### PR DESCRIPTION
This commit adds support for playing PROXX with a gamepad. The gamepad
can be used both on the game board, and in the menus. On the game board
it can be used to clear (A or LB) or flag (X or RB) tiles, navigate the
board using the D-Pad, and switch into alt mode (B). On the menu, A can
be used to confirm (Start or Restart) and B can be used to go back or
cancel.

I tried to keep this relatively light-weight, but it does add a bit of
extra code to the initial bundle (the Gamepad handling specifically). If
the user does not use a game pad, the code will not cause any extra CPU
usage.

I have tested this on a Steamdeck, and on a Linux machine using an Xbox
One controller.

See me trying it out on my Steamdeck here: https://www.youtube.com/watch?v=094whsi4pdw